### PR TITLE
Support for HTTPS and Basepath added

### DIFF
--- a/SubsonicSharp/ExtensionMethods.cs
+++ b/SubsonicSharp/ExtensionMethods.cs
@@ -127,5 +127,18 @@ namespace SubsonicSharp
         {
             return new DateTime(1970,1,1,0,0,0,DateTimeKind.Utc).AddMilliseconds(time);
         }
+
+        public static string ToFriendlyString(this ServerInfo.Protocol me)
+        {
+            switch (me)
+            {
+                case ServerInfo.Protocol.Http:
+                    return "http://";
+                case ServerInfo.Protocol.Https:
+                    return "https://";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(me), me, null);
+            }
+        }
     }
 }

--- a/SubsonicSharp/ServerInfo.cs
+++ b/SubsonicSharp/ServerInfo.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace SubsonicSharp
+﻿namespace SubsonicSharp
 {
     public class ServerInfo
     {
@@ -27,21 +25,5 @@ namespace SubsonicSharp
         public string BaseUrl() => $"{ConnectionProtocol.ToFriendlyString()}{Host}:{Port}{Basepath}";
 
         public string VersionString() => $"v=1.{ApiVersion}";
-    }
-
-    public static class ServerInfoExtensions
-    {
-        public static string ToFriendlyString(this ServerInfo.Protocol me)
-        {
-            switch (me)
-            {
-                case ServerInfo.Protocol.Http:
-                    return "http://";
-                case ServerInfo.Protocol.Https:
-                    return "https://";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(me), me, null);
-            }
-        }
     }
 }

--- a/SubsonicSharp/ServerInfo.cs
+++ b/SubsonicSharp/ServerInfo.cs
@@ -1,19 +1,47 @@
-﻿namespace SubsonicSharp
+﻿using System;
+
+namespace SubsonicSharp
 {
     public class ServerInfo
     {
-        public string Address { get; set; } //string to account to allow for hostname access without IP
+        public string Host { get; set; } //string to allow for hostname access without IP
         public int Port { get; set; } //Default port for HTTP is 4040
-        public int ApiVersion { get; set; } = 13; //Support for later versions to be addressed later
+        public string Basepath { get; set; } //Basepath, for example /ampache/
+        public int ApiVersion { get; set; } = 11; //Support for later versions to be addressed later
+        public Protocol ConnectionProtocol { get; set; } // HTTP/HTTPS protocol, default is HTTP
 
-        public ServerInfo(string address, int port = 4040)
+        public enum Protocol
         {
-            Address = address;
-            Port = port;
+            Http,
+            Https
         }
 
-        public string BaseUrl() => $"http://{Address}:{Port}";
+        public ServerInfo(string host, int port = 4040, string basepath = "", Protocol protocol = Protocol.Http)
+        {
+            Host = host;
+            Port = port;
+            Basepath = basepath;
+            ConnectionProtocol = protocol;
+        }
+
+        public string BaseUrl() => $"{ConnectionProtocol.ToFriendlyString()}{Host}:{Port}{Basepath}";
 
         public string VersionString() => $"v=1.{ApiVersion}";
+    }
+
+    public static class ServerInfoExtensions
+    {
+        public static string ToFriendlyString(this ServerInfo.Protocol me)
+        {
+            switch (me)
+            {
+                case ServerInfo.Protocol.Http:
+                    return "http://";
+                case ServerInfo.Protocol.Https:
+                    return "https://";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(me), me, null);
+            }
+        }
     }
 }

--- a/SubsonicSharp/SubsonicClient.cs
+++ b/SubsonicSharp/SubsonicClient.cs
@@ -27,8 +27,8 @@ namespace SubsonicSharp
         public Podcasts Podcasts { get; set; }
         public Chat Chat { get; set; }
 
-        public SubsonicClient(string username, string password, string address, int port = 4040)
-            : this(new UserToken(username, password), new ServerInfo(address, port))
+        public SubsonicClient(string username, string password, string address, int port = 4040, string basepath = "", ServerInfo.Protocol protocol = ServerInfo.Protocol.Http)
+            : this(new UserToken(username, password), new ServerInfo(address, port, basepath, protocol))
         {
         }
 

--- a/XamarinTest/XamarinTest.csproj.bak
+++ b/XamarinTest/XamarinTest.csproj.bak
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
I've added support for defining protocol (HTTP/HTTPS) and a Basepath, with defaults for both cases. I wrote it in such a way so that it doesn't break existing installations, i.e. all new stuff is optional with default values.